### PR TITLE
Added new functionality to download phytoplankton flags from CSIR.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -213,13 +213,12 @@ def main():
     # download_phytoplankton_flags
     # -------------------------
     parser_download_phytoplankton_flags = subparsers.add_parser('download_phytoplankton_flags',
-            help='Download and convert daily CSIR phytoplankton flags as NetCDF file via OPeNDAP')
-    parser_download_phytoplankton_flags.add_argument('--file_in', required=True,
-                                            help='Directory/URL and file name of the phytoplankton flags Geotif file.')
-    parser_download_phytoplankton_flags.add_argument('--file_out', required=True, 
-                                            help='File directory and name to save file the output NetCDF file.')
+                        help='Download the daily phytoplankton flags as NetCDF file from CSIR - https://www.ocims.gov.za/data/s3olci/s3-phytoplankton-south_africa ')
+    parser_download_phytoplankton_flags.add_argument('--date', required=True, type=parse_datetime,
+                        help='start time in format "YYYY-MM-DD HH:MM:SS"')
+    parser_download_phytoplankton_flags.add_argument('--dir_out', required=True, help='Directory to save files') 
     def download_phytoplankton_flags_handler(args):
-        download_phytoplankton_flags(args.file_in, args.file_out)
+        download_phytoplankton_flags(args.date, args.dir_out)
     parser_download_phytoplankton_flags.set_defaults(func=download_phytoplankton_flags_handler)
 
     args = parser.parse_args()

--- a/cli.py
+++ b/cli.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 from download_tools.cmems import download_cmems, download_cmems_monthly, download_mercator_ops
 from download_tools.gfs import download_gfs_atm
 from download_tools.hycom import download_hycom_ops, download_hycom_gofs31
+from download_tools.phyto import download_csir_flags
 
 # functions to help parsing string input to object types needed by python functions
 def parse_datetime(value):
@@ -207,6 +208,22 @@ def main():
         download_hycom_gofs31(args.domain, args.start_date, args.end_date, args.outputDir,
                               args.var_list, args.depths, args.surface)
     parser_download_hycom_gofs31.set_defaults(func=download_hycom_gofs31_handler)
+
+    # -------------------------
+    # download_csir_flags
+    # -------------------------
+    parser_download_csir_flags = subparsers.add_parser('download_csir_flags',
+            help='Download and convert daily CSIR phytoplankton flags as NetCDF file via OPeNDAP')
+    parser_download_csir_flags.add_argument('--run_date', required=True, 
+                                            help='date of file to download in format "YYYYMMDD"')
+    parser_download_csir_flags.add_argument('--data_dir', required=False, 
+                                            default='https://www.ocims.gov.za/data/s3olci/s3-phytoplankton-south_africa',
+                                            help='Directory/URL of source files')
+    parser_download_csir_flags.add_argument('--save_dir', required=True, 
+                                            help='Directory to save files')
+    def download_csir_flags_handler(args):
+        download_csir_flags(args.run_date, args.data_dir, args.save_dir)
+    parser_download_csir_flags.set_defaults(func=download_csir_flags_handler)
 
     args = parser.parse_args()
     if hasattr(args, 'func'):

--- a/cli.py
+++ b/cli.py
@@ -13,7 +13,7 @@ from datetime import datetime, timedelta
 from download_tools.cmems import download_cmems, download_cmems_monthly, download_mercator_ops
 from download_tools.gfs import download_gfs_atm
 from download_tools.hycom import download_hycom_ops, download_hycom_gofs31
-from download_tools.phyto import download_csir_flags
+from download_tools.phyto import download_phytoplankton_flags
 
 # functions to help parsing string input to object types needed by python functions
 def parse_datetime(value):
@@ -210,20 +210,17 @@ def main():
     parser_download_hycom_gofs31.set_defaults(func=download_hycom_gofs31_handler)
 
     # -------------------------
-    # download_csir_flags
+    # download_phytoplankton_flags
     # -------------------------
-    parser_download_csir_flags = subparsers.add_parser('download_csir_flags',
+    parser_download_phytoplankton_flags = subparsers.add_parser('download_phytoplankton_flags',
             help='Download and convert daily CSIR phytoplankton flags as NetCDF file via OPeNDAP')
-    parser_download_csir_flags.add_argument('--run_date', required=True, 
-                                            help='date of file to download in format "YYYYMMDD"')
-    parser_download_csir_flags.add_argument('--data_dir', required=False, 
-                                            default='https://www.ocims.gov.za/data/s3olci/s3-phytoplankton-south_africa',
-                                            help='Directory/URL of source files')
-    parser_download_csir_flags.add_argument('--save_dir', required=True, 
-                                            help='Directory to save files')
-    def download_csir_flags_handler(args):
-        download_csir_flags(args.run_date, args.data_dir, args.save_dir)
-    parser_download_csir_flags.set_defaults(func=download_csir_flags_handler)
+    parser_download_phytoplankton_flags.add_argument('--file_in', required=True,
+                                            help='Directory/URL and file name of the phytoplankton flags Geotif file.')
+    parser_download_phytoplankton_flags.add_argument('--file_out', required=True, 
+                                            help='File directory and name to save file the output NetCDF file.')
+    def download_phytoplankton_flags_handler(args):
+        download_phytoplankton_flags(args.file_in, args.file_out)
+    parser_download_phytoplankton_flags.set_defaults(func=download_phytoplankton_flags_handler)
 
     args = parser.parse_args()
     if hasattr(args, 'func'):

--- a/download_tools/phyto.py
+++ b/download_tools/phyto.py
@@ -1,0 +1,49 @@
+import os
+import rioxarray
+
+
+def download_csir_flags(run_date,data_dir,save_dir):
+    """
+    Function to convert CSIR phytoplankton flags from GeoTIF to NetCDF.
+
+    Parameters
+    ----------
+    run_date : str
+        Date string in format YYYYMMDD (e.g., '20260410')
+    data_dir : str
+        Path/URL to where TIF file is stored.
+    save_dir : str
+        Directory to save the NetCDF file
+
+    Returns
+    -------
+    str
+        Path to the saved NetCDF file
+    """
+
+    # Ensure output directory exists
+    os.makedirs(save_dir, exist_ok=True)
+
+    # Build file paths
+    tif_file = f"phyto_south_africa_{run_date}.tif"
+    nc_file = f"phyto_south_africa_{run_date}.nc"
+    
+    tif_path = os.path.join(data_dir, tif_file)
+    nc_path = os.path.join(save_dir, nc_file)
+
+    try:
+        print(f"Opening tif file: {tif_path}")
+        da = rioxarray.open_rasterio(tif_path)
+
+        print("Converting to xarray dataset...")
+        ds = da.to_dataset(name="phytoplankton")
+
+        print(f"Writing NetCDF to: {nc_path}")
+        ds.to_netcdf(nc_path)
+
+        print("All Done")
+        return nc_path
+
+    except Exception as e:
+        print(f"Error processing {run_date}: {e}")
+        raise

--- a/download_tools/phyto.py
+++ b/download_tools/phyto.py
@@ -1,28 +1,42 @@
 import rioxarray
+import pandas as pd
+import os
 
-def download_phytoplankton_flags(file_in,file_out):
+def download_phytoplankton_flags(date,output_dir):
     """
-    Function to download CSIR phytoplankton flags and save as NetCDF file.
+    Function to download CSIR phytoplankton flags and save as NetCDF file. CSIR 
+    disseminates the data freely using the link below: 
+        https://www.ocims.gov.za/data/s3olci/s3-phytoplankton-south_africa
 
     Parameters
     ----------
-    file_in : str
-        Path/URL to phytoplankton flags Geotif file
-    file_out : str
-        Directory and file name of the output NetCDF file
+    date : pandas datetime - datetime.datetime(YYYY,MM,DD)
+        Date of the phytoplankton flags to download from CSIR. 
+    dir_out : str
+        Directory to save downloaded phytoplankton flags to as a NetCDF file.
     """
     # Build file path
+    url = "https://www.ocims.gov.za/data/s3olci/s3-phytoplankton-south_africa"
+    file_in = os.path.join(url, f"phyto_south_africa_{date.strftime('%Y%m%d')}.tif" )
     try:
-        print(f"Opening tif file: {file_in}")
+        print(f"\nOpening tif file: {file_in}")
         da = rioxarray.open_rasterio(file_in)
 
-        print("Converting to xarray dataset...")
+        print("\nConverting to xarray dataset...")
         ds = da.to_dataset(name="phytoplankton")
 
-        print(f"Writing NetCDF to: {file_out}")
+        file_out = os.path.join(output_dir, f"PHYTO_{date.strftime('%Y%m%d_%H')}.nc")
+        print(f"\nWriting NetCDF to: {file_out}")
         ds.to_netcdf(file_out)
 
-        print("All Done")
+        print("\nAll Done")
     except Exception as e:
         print(f"Error processing {file_in}: {e}")
         raise
+        
+        
+if __name__ == '__main__':
+    date = pd.to_datetime('2025-08-22 00:00:00')
+    output_dir = '/home/g.rautenbach/Data/OLCHI'
+    download_phytoplankton_flags(date, output_dir)
+

--- a/download_tools/phyto.py
+++ b/download_tools/phyto.py
@@ -1,49 +1,28 @@
-import os
 import rioxarray
 
-
-def download_csir_flags(run_date,data_dir,save_dir):
+def download_phytoplankton_flags(file_in,file_out):
     """
-    Function to convert CSIR phytoplankton flags from GeoTIF to NetCDF.
+    Function to download CSIR phytoplankton flags and save as NetCDF file.
 
     Parameters
     ----------
-    run_date : str
-        Date string in format YYYYMMDD (e.g., '20260410')
-    data_dir : str
-        Path/URL to where TIF file is stored.
-    save_dir : str
-        Directory to save the NetCDF file
-
-    Returns
-    -------
-    str
-        Path to the saved NetCDF file
+    file_in : str
+        Path/URL to phytoplankton flags Geotif file
+    file_out : str
+        Directory and file name of the output NetCDF file
     """
-
-    # Ensure output directory exists
-    os.makedirs(save_dir, exist_ok=True)
-
-    # Build file paths
-    tif_file = f"phyto_south_africa_{run_date}.tif"
-    nc_file = f"phyto_south_africa_{run_date}.nc"
-    
-    tif_path = os.path.join(data_dir, tif_file)
-    nc_path = os.path.join(save_dir, nc_file)
-
+    # Build file path
     try:
-        print(f"Opening tif file: {tif_path}")
-        da = rioxarray.open_rasterio(tif_path)
+        print(f"Opening tif file: {file_in}")
+        da = rioxarray.open_rasterio(file_in)
 
         print("Converting to xarray dataset...")
         ds = da.to_dataset(name="phytoplankton")
 
-        print(f"Writing NetCDF to: {nc_path}")
-        ds.to_netcdf(nc_path)
+        print(f"Writing NetCDF to: {file_out}")
+        ds.to_netcdf(file_out)
 
         print("All Done")
-        return nc_path
-
     except Exception as e:
         print(f"Error processing {run_date}: {e}")
         raise

--- a/download_tools/phyto.py
+++ b/download_tools/phyto.py
@@ -24,5 +24,5 @@ def download_phytoplankton_flags(file_in,file_out):
 
         print("All Done")
     except Exception as e:
-        print(f"Error processing {run_date}: {e}")
+        print(f"Error processing {file_in}: {e}")
         raise

--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - pandas
   - zarr>=3
   - copernicusmarine
+  - rioxarray

--- a/environment.yml
+++ b/environment.yml
@@ -2,13 +2,13 @@ name: download
 channels:
   - conda-forge
 dependencies:
-  - python >=3.11
-  - numpy>=1.17
-  - netcdf4<=1.6.1
-  - xarray>=2023.4.0
-  - dask>=2023.4.0
+  - python=3.11
+  - numpy
+  - netcdf4
+  - xarray
+  - dask
   - pathlib
   - pandas
-  - zarr>=3
+  - zarr
   - copernicusmarine
   - rioxarray


### PR DESCRIPTION
Simple function which downloads the CSIR phytoplankton flags and saves it as a netcdf file - [link](https://github.com/SAEON/somisana-download/blob/download-phyto-flags/download_tools/phyto.py) to function. 
This is used operationally to advect Harmful Algal Blooms in the [somisana-opendrift](https://github.com/SAEON/somisana-opendrift) repo.

The function can also be use to convert the tif file locally into a netcdf file, but I don't see how that is usefull in our case, unless if you just want to play around with the advection drift, but its not like the download takes long at all.

I did have to include an additional package, rioxarray, which does not seem to cause any dependency issues in this repo. This has been included in the [environment.yml](https://github.com/SAEON/somisana-download/blob/download-phyto-flags/environment.yml) file.

I have also included it in the [cli.py](https://github.com/SAEON/somisana-download/blob/download-phyto-flags/cli.py) so that we can use it in the operational workflow. 

